### PR TITLE
TA-27409. Support for database URI query string options.

### DIFF
--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -91,7 +91,7 @@ module Knockoff
                 'password' => uri.password,
                 'host' => uri.host,
                 'port' => uri.port
-              }
+              }.merge(Rack::Utils.parse_query(uri.query))
             end
 
           # Store the hash in configuration and use it when we establish the connection later.


### PR DESCRIPTION
Support query string parameters when converting database URI into ActiveRecord configurations.

I tested this in `thanx-admin` and it worked as expected. Extra kwargs appear to be ignored by the database adapter for mysql but I can't guarantee it will work for all adapters without further research. For that reason, I am not going to PR this back into the original repo.